### PR TITLE
remove gcc warnings

### DIFF
--- a/src/recompress.c
+++ b/src/recompress.c
@@ -107,7 +107,7 @@ void recompress_entry(FILE *infile,
     return;
   }
 
-  printf("%-32s : %ld -> ", filename, src_size);
+  printf("%-32s : %zd -> ", filename, src_size);
 
   size_t uncomp_size = header->uncomp_size;
   uchar *tmp = (uchar *)allocate_or_exit(uncomp_size);
@@ -125,7 +125,7 @@ void recompress_entry(FILE *infile,
   }
 
   header->comp_size = dst_size;
-  printf("%ld bytes (%ld bytes)\n", dst_size, dst_size - src_size);
+  printf("%zd bytes (%zd bytes)\n", dst_size, dst_size - src_size);
 
   write_local_file_header(outfile, header);
   write_bytes(dst, dst_size, outfile);

--- a/src/recompress.c
+++ b/src/recompress.c
@@ -21,6 +21,8 @@
  *    distribution.
  */
 
+#include <string.h>
+
 #include <zlib.h>
 #include "zipzop.h"
 #include "deflate.h"

--- a/src/recompress.c
+++ b/src/recompress.c
@@ -105,7 +105,7 @@ void recompress_entry(FILE *infile,
     return;
   }
 
-  printf("%-32s : %d -> ", filename, src_size);
+  printf("%-32s : %ld -> ", filename, src_size);
 
   size_t uncomp_size = header->uncomp_size;
   uchar *tmp = (uchar *)allocate_or_exit(uncomp_size);
@@ -123,7 +123,7 @@ void recompress_entry(FILE *infile,
   }
 
   header->comp_size = dst_size;
-  printf("%d bytes (%d bytes)\n", dst_size, dst_size - src_size);
+  printf("%ld bytes (%ld bytes)\n", dst_size, dst_size - src_size);
 
   write_local_file_header(outfile, header);
   write_bytes(dst, dst_size, outfile);

--- a/src/zipzop.c
+++ b/src/zipzop.c
@@ -109,7 +109,7 @@ void show_result_size(FILE *infile, FILE *outfile) {
   size_t recomp = ftell(outfile);
 
   u32 diff = (int)recomp - orig;
-  printf("\noriginal -> recompressed\n\t%ld -> %ld bytes (%ld bytes)\n", orig, recomp, diff);
+  printf("\noriginal -> recompressed\n\t%zd -> %zd bytes (%ld bytes)\n", orig, recomp, diff);
 }
 
 int main(int argc, char **argv) {

--- a/src/zipzop.c
+++ b/src/zipzop.c
@@ -109,7 +109,7 @@ void show_result_size(FILE *infile, FILE *outfile) {
   size_t recomp = ftell(outfile);
 
   u32 diff = (int)recomp - orig;
-  printf("\noriginal -> recompressed\n\t%d -> %d bytes (%ld bytes)\n", orig, recomp, diff);
+  printf("\noriginal -> recompressed\n\t%ld -> %ld bytes (%ld bytes)\n", orig, recomp, diff);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The following errors is output in my environment(Debian squeeze & GCC4.4.5).

```
src/recompress.c:73: warning: implicit declaration of function ‘strncpy’
src/recompress.c:73: warning: incompatible implicit declaration of built-in function ‘strncpy’
src/recompress.c:84: warning: incompatible implicit declaration of built-in function ‘strncpy’
src/recompress.c: In function ‘recompress_entry’:
src/recompress.c:108: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘size_t’
src/recompress.c:126: warning: format ‘%d’ expects type ‘int’, but argument 2 has type ‘size_t’
src/recompress.c:126: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘size_t’
```

This patch will remove them.
