### PR TITLE
Few improvements, like free(tmp) @recompress_entry();

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,75 +1,49 @@
 PREFIX =
 
+ZOPFLI_DIR = zopfli
+
 CC = $(PREFIX)gcc
-OPT_CFLAGS = 
-CFLAGS = -c -O2 -W -Wall -Wextra $(OPT_CFLAGS)
+OPT_CFLAGS = -O2
+DEBUG =
+WARN = -W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable
+CFLAGS = -c $(DEBUG) $(OPT_CFLAGS) $(WARN) $(DEFINES)
+INCLUDES = -I$(ZOPFLI_DIR)/src/zopfli
 
 LD = $(PREFIX)gcc
-OPT_LDFLAGS = 
-LDFLAGS = -lz -lm $(OPT_LDFLAGS)
+OPT_LDFLAGS =
+LDFLAGS = $(OPT_LDFLAGS)
 
 ZIPZOP_OBJS = header.o recompress.o zz_util.o zipzop.o
-ZOPFLI_OBJS = blocksplitter.o cache.o deflate.o hash.o katajainen.o lz77.o squeeze.o tree.o util.o zopfli_lib.o zlib_container.o gzip_container.o
-OBJS = $(ZOPFLI_OBJS) $(ZIPZOP_OBJS)
+ZOPFLI_OBJS = $(ZOPFLI_DIR)/libzopfli.a
+#OBJS = $(ZOPFLI_OBJS) $(ZIPZOP_OBJS)
+OBJS = $(ZIPZOP_OBJS)
+LIBS = -lz -lm -L$(ZOPFLI_DIR) -lzopfli
 
-E = 
+E =
 TARGET = zipzop$(E)
 
 $(TARGET): $(OBJS)
-	$(LD) $(OBJS) $(LDFLAGS) -o $(TARGET)
-	strip $(TARGET)
+	$(LD) $(LDFLAGS) -o $(TARGET) $(OBJS) $(LIBS)
+#	strip $(TARGET)
 
 header.o: src/header.c
-	$(CC) $< -I./zopfli $(CFLAGS)
-recompress.o: src/recompress.c zopfli/deflate.h
-	$(CC) $< -I./zopfli $(CFLAGS)
+	$(CC) $< $(CFLAGS) $(INCLUDES)
+recompress.o: src/recompress.c $(ZOPFLI_DIR)/src/zopfli/deflate.h
+	$(CC) $< $(CFLAGS) $(INCLUDES)
 zz_util.o: src/zz_util.c
-	$(CC) $< -I./zopfli $(CFLAGS)
+	$(CC) $< $(CFLAGS) $(INCLUDES)
 zipzop.o: src/zipzop.c
-	$(CC) $< -I./zopfli $(CFLAGS)
+	$(CC) $< $(CFLAGS) $(INCLUDES)
 
-blocksplitter.o: zopfli/blocksplitter.c
-	$(CC) $< $(CFLAGS)
-cache.o: zopfli/cache.c
-	$(CC) $< $(CFLAGS)
-deflate.o: zopfli/deflate.c
-	$(CC) $< $(CFLAGS)
-hash.o: zopfli/hash.c
-	$(CC) $< $(CFLAGS)
-katajainen.o: zopfli/katajainen.c
-	$(CC) $< $(CFLAGS)
-lz77.o: zopfli/lz77.c
-	$(CC) $< $(CFLAGS)
-squeeze.o: zopfli/squeeze.c
-	$(CC) $< $(CFLAGS)
-tree.o: zopfli/tree.c
-	$(CC) $< $(CFLAGS)
-util.o: zopfli/util.c
-	$(CC) $< $(CFLAGS)
-zopfli_lib.o: zopfli/zopfli_lib.c
-	$(CC) $< $(CFLAGS)
-zlib_container.o: zopfli/zlib_container.c
-	$(CC) $< $(CFLAGS)
-gzip_container.o: zopfli/gzip_container.c
-	$(CC) $< $(CFLAGS)
 
-zopfli/blocksplitter.c: zopfli
-zopfli/cache.c: zopfli
-zopfli/deflate.c: zopfli
-zopfli/deflate.h: zopfli
-zopfli/hash.c: zopfli
-zopfli/katajainen.c: zopfli
-zopfli/lz77.c: zopfli
-zopfli/squeeze.c: zopfli
-zopfli/tree.c: zopfli
-zopfli/util.c: zopfli
-zopfli/zopfli_lib.c: zopfli
-zopfli/zlib_container.c: zopfli
-zopfli/gzip_container.c: zopfli
+zopfli: zopfli
+	git clone https://github.com/google/zopfli
+	make -C zopfli
 
-zopfli:
-	git clone https://code.google.com/p/zopfli/
 
 clean:
-	rm -rf zopfli *.o $(TARGET)
+	rm -rf *.o $(TARGET)
+
+distclean:
+	rm -Rf zopfli
 

--- a/README.jp.md
+++ b/README.jp.md
@@ -1,0 +1,61 @@
+zipzop
+======
+
+Zip archive recompressor with Google's zopfli library.
+
+
+概要
+----
+
+Google による deflate 圧縮アルゴリズムの圧縮率最適化実装 [zopfli](https://code.google.com/p/zopfli/) を利用して Zip アーカイブを圧縮し直し、アーカイブサイズの削減を試みるツールです。
+
+
+必要なもの
+----------
+
+ - [zlib](http://www.zlib.net/)
+   - deflate 圧縮されたアーカイブ内のファイルを復元するために利用しています。
+
+ - git
+   - zopfli のソースコードを取得する際に利用しています。
+
+
+使い方
+------
+
+以下のコマンドを実行することで、実行可能なバイナリ `zipzop` が生成されます。
+
+    $ git clone git://github.com/komiya-atsushi/zipzop.git
+    $ make
+
+`make install` みたいな気の利いたものは用意していませんので、適当に `zipzop` をお使いください。
+
+    $ zipzop NUM_ITERATIONS IN_FILE OUT_FILE
+
+ - `NUM_ITERATIONS` ... 圧縮最適化を頑張る回数です。1 以上の数値を指定します。大きな値を指定すればするほどちょっとずつ圧縮率が改善しますが、数値に比例して処理時間がかかるようになります。
+ - `IN_FILE` ... 再圧縮したい Zip アーカイブを指定します。
+ - `OUT_FILE` ... 再圧縮後の Zip アーカイブの名前を指定します。既存のファイルを上書きして出力しようとするのでご注意ください。
+
+
+制限
+----
+
+ - 再圧縮ができるのは deflate 圧縮されたファイルのみです。deflate64 を含め、その他の圧縮メソッドにより圧縮されたファイルは再圧縮せずにそのままアーカイブに出力されます。
+ - 暗号化された Zip アーカイブは処理できません。
+
+
+ライセンス
+----------
+
+zlib / libpng ライセンスです。詳しくは license.txt をお読み下さい。
+
+
+謝辞
+----
+
+このプログラムは以下のライブラリを利用しています。
+
+ - zopfli ( Copyright 2011 Google Inc. All Rights Reserved. )
+ - zlib ( Copyright 1995-2012 Jean-loup Gailly and Mark Adler. )
+
+   

--- a/README.md
+++ b/README.md
@@ -1,61 +1,60 @@
 zipzop
 ======
 
-Zip archive recompressor with Google's zopfli library.
+Zip archive recompressor using Google's zopfli library.
 
 
-概要
+Overview
 ----
 
-Google による deflate 圧縮アルゴリズムの圧縮率最適化実装 [zopfli](https://code.google.com/p/zopfli/) を利用して Zip アーカイブを圧縮し直し、アーカイブサイズの削減を試みるツールです。
+Zipzop is recompression tool that uses Google's compression ratio optimization implementation of the deflate compression algorithm [zopfli](https://github.com/google/zopfli) recompress Zip archives and try to reduce the archive size.
 
 
-必要なもの
-----------
+Things necessary
+----
 
  - [zlib](http://www.zlib.net/)
-   - deflate 圧縮されたアーカイブ内のファイルを復元するために利用しています。
+   - deflate is used to decompress files in compressed archives.
 
- - git
-   - zopfli のソースコードを取得する際に利用しています。
+ - [git](https://git-scm.com/)
+   - It is used to get the source code of [zopfli](https://github.com/google/zopfli).
 
 
-使い方
-------
+How to use
+----
 
-以下のコマンドを実行することで、実行可能なバイナリ `zipzop` が生成されます。
+The following command will generate an executable binary `zipzop`.
 
-    $ git clone git://github.com/komiya-atsushi/zipzop.git
+    $ git clone git: //github.com/komiya-atsushi/zipzop.git
     $ make
 
-`make install` みたいな気の利いたものは用意していませんので、適当に `zipzop` をお使いください。
+There are no nice thing like `make install`, so please use `zipzop` appropriately.
 
     $ zipzop NUM_ITERATIONS IN_FILE OUT_FILE
 
- - `NUM_ITERATIONS` ... 圧縮最適化を頑張る回数です。1 以上の数値を指定します。大きな値を指定すればするほどちょっとずつ圧縮率が改善しますが、数値に比例して処理時間がかかるようになります。
- - `IN_FILE` ... 再圧縮したい Zip アーカイブを指定します。
- - `OUT_FILE` ... 再圧縮後の Zip アーカイブの名前を指定します。既存のファイルを上書きして出力しようとするのでご注意ください。
+ - `NUM_ITERATIONS` ... The number of times to work hard on compression optimization. Specify a number greater than or equal to 1. The larger the value, the better the compression ratio will be, but the processing time will increase in proportion to the value.
+ - `IN_FILE` ... Specify the Zip archive you want to recompress.
+ - `OUT_FILE` ... Specifies the name of the Zip archive after recompression. Please note that it will overwrite the existing file and try to output it.
 
 
-制限
+Limitations
 ----
 
- - 再圧縮ができるのは deflate 圧縮されたファイルのみです。deflate64 を含め、その他の圧縮メソッドにより圧縮されたファイルは再圧縮せずにそのままアーカイブに出力されます。
- - 暗号化された Zip アーカイブは処理できません。
+ - Only deflate-compressed files can be recompressed. Files compressed by other compression methods, including deflate64, are output to the archive as is without being recompressed.
+ - Cannot process encrypted Zip archives.
 
 
-ライセンス
-----------
-
-zlib / libpng ライセンスです。詳しくは license.txt をお読み下さい。
-
-
-謝辞
+License
 ----
 
-このプログラムは以下のライブラリを利用しています。
+zlib / libpng license. Please read license.txt for details.
 
- - zopfli ( Copyright 2011 Google Inc. All Rights Reserved. )
- - zlib ( Copyright 1995-2012 Jean-loup Gailly and Mark Adler. )
 
-   
+Acknowledgments
+----
+
+This program uses the following libraries:
+
+ - zopfli (Copyright 2011 Google Inc. All Rights Reserved.)
+ - zlib (Copyright 1995-2012 Jean-loup Gailly and Mark Adler.)
+

--- a/src/recompress.c
+++ b/src/recompress.c
@@ -73,11 +73,11 @@ static void copy_filename_suffix(const char *src, size_t src_size,
 				 char *buf, size_t buf_size) {
   if (src_size <= buf_size) {
     strncpy(buf, src, src_size);
-    
+
     if (src_size < buf_size) {
       buf[src_size] = '\0';
     }
-    
+
     return;
   }
 
@@ -99,7 +99,7 @@ void recompress_entry(FILE *infile,
   size_t src_size = header->comp_size;
   uchar *src = (uchar *)allocate_or_exit(src_size);
   read_bytes(src, src_size, infile);
-  
+
   if (header->method != METHOD_DEFLATE) {
     write_local_file_header(outfile, header);
     write_bytes(src, src_size, outfile);
@@ -132,4 +132,5 @@ void recompress_entry(FILE *infile,
 
   free(dst);
   free(src);
+  free(tmp);
 }

--- a/src/zipzop.c
+++ b/src/zipzop.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "zipzop.h"
 
@@ -70,7 +71,7 @@ void recompress_zip(FILE *infile, FILE *outfile, int num_iterations) {
     if (IS_LOCAL_FILE_HEADER(header->signature)) {
       LocalFileHeader *_header = (LocalFileHeader *)header;
       comp_result[file_count].offset = ftell(outfile);
-      
+
       recompress_entry(infile, outfile, _header, num_iterations);
 
       comp_result[file_count].comp_size = _header->comp_size;
@@ -79,7 +80,7 @@ void recompress_zip(FILE *infile, FILE *outfile, int num_iterations) {
 
     } else if (IS_CENTRAL_DIRECTORY_FILE_HEADER(header->signature)) {
       if (central_dir_offset == 0xffffffff) {
-	central_dir_offset = ftell(outfile);
+        central_dir_offset = ftell(outfile);
       }
       CentralDirectoryFileHeader *_header = (CentralDirectoryFileHeader *)header;
 
@@ -122,6 +123,11 @@ int main(int argc, char **argv) {
   if (num_iterations <= 0) {
     printf("ERROR: Invalid iteration count: %s\n", argv[1]);
   }
+
+  if (strcmp(argv[2], argv[3]) == 0) {
+    printf("ERROR: input file specified as output: %s\n", argv[3]);
+    return 1;
+    }
 
   FILE *infile = fopen(argv[2], "rb");
   if (infile == NULL) {

--- a/test/youtube-dl.zip.sh
+++ b/test/youtube-dl.zip.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+wget https://youtube-dl.org/downloads/latest/youtube-dl
+tail -n +2 < youtube-dl > youtube-dl.zip


### PR DESCRIPTION
improved Makefile; English README; prevented overwriting input; test file

I made few improvements:
-- Added `free(tmp);` @[recompress_entry()](https://github.com/tansy/zipzop-ld/blob/1ee67d2d79a9a73ca907e3343b644950daea6177/src/recompress.c#L135).
-- Improved Makefile
-- Translated README to English
-- [Added check](https://github.com/tansy/zipzop-ld/blob/1ee67d2d79a9a73ca907e3343b644950daea6177/src/zipzop.c#L127) of input file names to prevent overwriting input
-- Added test file (well, a script to download it)

There still is a leak somewhere but I couldn't to pinpoint it. That's why I included test file - it is about 1.8MB but contains lot of small files and memory consumption grows to almost 40MB.
